### PR TITLE
Implement adapted humanpanic error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "env_logger",
  "futures",
  "gilrs",
+ "human-panic",
  "lazy_static",
  "libc",
  "log",
@@ -1394,6 +1395,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "human-panic"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f357a500abcbd7c5f967c1d45c8838585b36743823b9d43488f24850534e36"
+dependencies = [
+ "backtrace",
+ "os_type",
+ "serde",
+ "serde_derive",
+ "termcolor",
+ "toml",
+ "uuid",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "os_type"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
+dependencies = [
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ autopilot = "0.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.74"
-x11 = { version = "2.18.2", features = ["xlib", "xinput"] }
+x11 = { version = "2.18.2", features = ["xlib", "xinput", "xrandr"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2.74"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ conquer-once = "0.2.1"
 uuid = { version = "0.8.1", features = ["v4"] }
 confy = "0.4.0"
 autopilot = "0.4.0"
+tinyfiledialogs = "3.3.0"
+human-panic = "1.0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.74"
@@ -40,9 +42,6 @@ objc = "0.2.7"
 cocoa = "0.23.0"
 block = "0.1.6"
 core-foundation = "0.9.0"
-
-[target.'cfg(target_os = "windows")'.dependencies]
-tinyfiledialogs = "3.3.0"
 
 [package.metadata.bundle]
 name = "Conductor"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ mod resources;
 mod util;
 mod webserver;
 mod scrn;
+mod panic;
+
 use cfg::Config;
+use std::panic::PanicInfo;
+use tinyfiledialogs::{message_box_ok, MessageBoxIcon};
 
 mod state;
 
@@ -25,6 +29,13 @@ const PERCENT_HEIGHT: f64 = 0.390625;
 fn main() -> WVResult {
     env_logger::init();
     let mut cfg = confy::load::<Config>("conductor").unwrap();
+    // std::panic::set_hook(Box::new(panic_dialog_creator));
+    match std::env::var("RUST_BACKTRACE") {
+        Err(_) => {
+            std::panic::set_hook(Box::new(panic::hook));
+        }
+        Ok(_) => {}
+    }
 
     // You're welcome dalton :)
     #[cfg(target_os = "windows")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ mod keys;
 mod panic;
 mod resources;
 mod scrn;
-mod scrn;
 mod util;
 mod webserver;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,12 @@ mod cfg;
 mod input;
 mod ipc;
 mod keys;
+mod panic;
 mod resources;
+mod scrn;
 mod scrn;
 mod util;
 mod webserver;
-mod scrn;
-mod panic;
 
 use cfg::Config;
 use std::panic::PanicInfo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod keys;
 mod resources;
 mod util;
 mod webserver;
+mod scrn;
 use cfg::Config;
 
 mod state;
@@ -42,13 +43,14 @@ fn main() -> WVResult {
     let port = webserver::launch_webserver(state.clone(), tx, stdout_tx);
     println!("Webserver launched on port {}", port);
 
-    let screen_size = autopilot::screen::size();
+    // let screen_size = autopilot::screen::size();
+    let (width, height) = unsafe { scrn::screen_resolution() };
 
-    println!("{} {}", (screen_size.width * PERCENT_WIDTH) as i32, (screen_size.height * PERCENT_HEIGHT) as i32);
+    println!("{} {}", (width * PERCENT_WIDTH) as i32, (height * PERCENT_HEIGHT) as i32);
     let mut webview = web_view::builder()
         .title("Conductor DS")
         .content(Content::Url(&format!("http://localhost:{}", port)))
-        .size((screen_size.width * PERCENT_WIDTH) as i32, (screen_size.height * PERCENT_HEIGHT) as i32)
+        .size((width * PERCENT_WIDTH) as i32, (height * PERCENT_HEIGHT) as i32)
         .resizable(false)
         .debug(true)
         .user_data(())

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,8 +1,8 @@
-use human_panic::{Metadata, handle_dump};
-use std::path::Path;
-use std::panic::PanicInfo;
+use human_panic::{handle_dump, Metadata};
 use std::fmt::Result as FmtResult;
 use std::fmt::Write;
+use std::panic::PanicInfo;
+use std::path::Path;
 use tinyfiledialogs::{message_box_ok, MessageBoxIcon};
 
 pub fn hook(info: &PanicInfo) {
@@ -51,7 +51,6 @@ pub fn create_msg<P: AsRef<Path>>(
      people to submit reports.\n"
     )?;
     writeln!(&mut buffer, "Thank you kindly!")?;
-
 
     Ok(buffer)
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,57 @@
+use human_panic::{Metadata, handle_dump};
+use std::path::Path;
+use std::panic::PanicInfo;
+use std::fmt::Result as FmtResult;
+use std::fmt::Write;
+use tinyfiledialogs::{message_box_ok, MessageBoxIcon};
+
+pub fn hook(info: &PanicInfo) {
+    let meta = Metadata {
+        version: env!("CARGO_PKG_VERSION").into(),
+        name: env!("CARGO_PKG_NAME").into(),
+        authors: env!("CARGO_PKG_AUTHORS").replace(":", ", ").into(),
+        homepage: env!("CARGO_PKG_HOMEPAGE").into(),
+    };
+
+    let file = handle_dump(&meta, info);
+    let msg = create_msg(file, &meta).expect("Failed to create error message");
+    message_box_ok("An Unexpected Error Occured", &msg, MessageBoxIcon::Error);
+}
+
+pub fn create_msg<P: AsRef<Path>>(
+    file_path: Option<P>,
+    meta: &Metadata,
+) -> Result<String, std::fmt::Error> {
+    let (_version, name, authors, homepage) =
+        (&meta.version, &meta.name, &meta.authors, &meta.homepage);
+
+    let mut buffer = String::new();
+
+    writeln!(&mut buffer, "Well, this is embarrassing.\n")?;
+    writeln!(
+        &mut buffer,
+        "{} had a problem and crashed. To help diagnose the \
+     problem you can send us a crash report.\n",
+        name
+    )?;
+    writeln!(
+        &mut buffer,
+        "A report file has been generated at \"{}\". Submit an \
+     issue and include the \
+     details in the report file so that I can diagnose the error.\n",
+        match file_path {
+            Some(fp) => format!("{}", fp.as_ref().display()),
+            None => "<Failed to store file to disk>".to_string(),
+        }
+    )?;
+
+    writeln!(
+        &mut buffer,
+        "\nConductor does not perform automated error collection. In order to improve the software, I rely on \
+     people to submit reports.\n"
+    )?;
+    writeln!(&mut buffer, "Thank you kindly!")?;
+
+
+    Ok(buffer)
+}

--- a/src/scrn.rs
+++ b/src/scrn.rs
@@ -1,0 +1,13 @@
+pub use self::arch::*;
+
+#[cfg(target_os = "linux")]
+#[path = "scrn/linux.rs"]
+mod arch;
+
+#[cfg(target_os = "macos")]
+#[path = "scrn/mac.rs"]
+mod arch;
+
+#[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
+#[path = "scrn/default.rs"]
+mod arch;

--- a/src/scrn/default.rs
+++ b/src/scrn/default.rs
@@ -1,0 +1,4 @@
+
+pub fn screen_resolution() -> (f64, f64) {
+    (0.0, 0.0)
+}

--- a/src/scrn/linux.rs
+++ b/src/scrn/linux.rs
@@ -1,0 +1,24 @@
+use x11::xlib::{XOpenDisplay, XDefaultRootWindow, XFree, XCloseDisplay};
+use std::ptr;
+use x11::xrandr::{XRRGetScreenResources, XRRGetCrtcInfo, XRRFreeCrtcInfo, XRRFreeScreenResources};
+
+
+pub unsafe fn screen_resolution() -> (f64, f64) {
+    let disp = XOpenDisplay(ptr::null_mut());
+    let def_wnd = XDefaultRootWindow(disp);
+    let screens = XRRGetScreenResources(disp, def_wnd);
+
+    // Get screen 0, use those dimensions
+    if (*screens).ncrtc != 0 {
+        let info = XRRGetCrtcInfo(disp, screens, *(*screens).crtcs);
+        let width = (*info).width;
+        let height = (*info).height;
+        XRRFreeCrtcInfo(info);
+        XRRFreeScreenResources(screens);
+        XCloseDisplay(disp);
+        (width as f64, height as f64)
+    } else {
+        println!("Could not detect any screens.");
+        (0.0, 0.0)
+    }
+}


### PR DESCRIPTION
Allows a way to verify when the backend silently dies because of some unknown reason, ie. unexpected protocol states. Popup will be displayed and backtrace information generated and thrown into the relevant tmpdir, which can then be shared on github for easier debugging should the need arise.