### PR TITLE
Add build script for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,32 @@ cargo install cargo-bundle
 # Conductor
 git clone https://github.com/Redrield/Conductor
 make setup && make release
+```  
+  
+## Mac
 ```
+# Homebrew Install
+xcode-select --install
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install webkitgtk
+
+# Node Version Manager
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+nvm install 14
+nvm use 14
+
+# Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+cargo install cargo-bundle
+
+# Conductor
+git clone https://github.com/Redrield/Conductor
+make setup && make release
+```  
 
 Building a release build of Conductor is simple; after cloning the repository run `make setup && make release` to install all the dependencies of the react applications, and then compile both the React apps and the Rust backend into a single executable. When this process is completed, you can find the compiled driver station at `target/release/conductor`. 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,28 @@ Before building, ensure that you have the following dependencies installed:
 
 - A Rust toolchain (e.g. installed via [Rustup](https://rustup.rs))
 - [NodeJS](https://nodejs.org) with NPM
-- [WebKitGTK](https://webkitgtk.org/)
+- [WebKitGTK](https://webkitgtk.org/)  
+
+## Ubuntu
+```
+# Dependencies
+sudo apt-get install -y nodejs libudev-dev libx11-dev libxi-dev libpango1.0-dev libatk1.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev
+
+# Node Version Manager
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+nvm install 14
+nvm use 14
+
+# Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+cargo install cargo-bundle
+
+make setup && make release
+```
 
 Building a release build of Conductor is simple; after cloning the repository run `make setup && make release` to install all the dependencies of the react applications, and then compile both the React apps and the Rust backend into a single executable. When this process is completed, you can find the compiled driver station at `target/release/conductor`. 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 cargo install cargo-bundle
 
+# Conductor
+git clone https://github.com/Redrield/Conductor
 make setup && make release
 ```
 


### PR DESCRIPTION
Script installs dependencies and configures node for version 14. Currently using the latest version of NVM, might need to change v0.39.3 to latest.