### PR TITLE
Builds for macOS AArch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license-file = "LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-web-view = { git = "https://github.com/Boscop/web-view" }
+web-view = { git = "https://github.com/Boscop/web-view#82d7cbc.git" }
 lazy_static = "1.4.0"
 rust-embed = "5.5.1"
 serde = { version = "1.0.106", features = ["derive"] }


### PR DESCRIPTION
Updated `Cargo.toml` to point to an updated commit of `webview-sys` so it builds on an Arm Mac. 

If anyone encounters `error:0308010C` during `make setup`, run `export NODE_OPTIONS=--openssl-legacy-provider`, source [on StackOverflow](https://stackoverflow.com/a/69699772).

Also you may want to update the README to say that WebKitGTK is only required for Linux builds.