### PR TITLE
Fix bug in install script in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ cargo install cargo-bundle
 
 # Conductor
 git clone https://github.com/Redrield/Conductor
+cd Conductor
 make setup && make release
 ```  
   
@@ -59,6 +60,7 @@ cargo install cargo-bundle
 
 # Conductor
 git clone https://github.com/Redrield/Conductor
+cd Conductor
 make setup && make release
 ```  
 


### PR DESCRIPTION
The install scripts in the readme do not work. I fixed this issue by just adding a cd to the install.